### PR TITLE
Update job title to Head of Developer Experience & Relations

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -31,7 +31,7 @@
       loading="lazy"
     />
     <p>
-      My name is <strong>Phil Leggetter</strong>. I'm Head of PLG and DevRel at
+      My name is <strong>Phil Leggetter</strong>. I'm Head of Developer Experience & Relations at
       <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>, an Event Gateway for event-driven
       applications.
     </p>

--- a/src/lib/site.mjs
+++ b/src/lib/site.mjs
@@ -1,7 +1,7 @@
 export const SITE_TITLE = 'Phil Leggetter';
 export const SITE_URL = 'https://www.leggetter.co.uk';
 export const SITE_TAGLINE_HTML =
-  'Head of PLG and Developer Relations at <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>';
+  'Head of Developer Experience & Relations at <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>';
 export const SITE_DESCRIPTION =
   "Phil Leggetter's website and blog: developer relations, developer experience, product-led growth, and realtime web technologies.";
 

--- a/src/pages/about-phil-leggetter.md
+++ b/src/pages/about-phil-leggetter.md
@@ -1,7 +1,7 @@
 ---
 layout: ../layouts/MarkdownPage.astro
 title: About Phil Leggetter
-description: "About Phil Leggetter: Head of PLG and DevRel at Hookdeck; Developer Experience, Developer Relations, Developer Marketing, and Product-Led Growth leader and advisor."
+description: "About Phil Leggetter: Head of Developer Experience & Relations at Hookdeck; Developer Experience, Developer Relations, Developer Marketing, and Product-Led Growth leader and advisor."
 sidebar: false
 ---
 
@@ -14,7 +14,7 @@ sidebar: false
   height="200"
 />
 
-My name is **Phil Leggetter**. I'm Head of PLG and DevRel at
+My name is **Phil Leggetter**. I'm Head of Developer Experience & Relations at
 <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>, an Event Gateway for
 event-driven applications.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ const knownFor = [
     <div class="home-hero__intro">
       <h1>Hi, I'm Phil Leggetter.</h1>
       <p>
-        I'm Head of PLG and DevRel at <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>, an
+        I'm Head of Developer Experience & Relations at <a href="https://hookdeck.com?ref=leggetter">Hookdeck</a>, an
         Event Gateway for event-driven applications.
       </p>
       <p>


### PR DESCRIPTION
Corrects the job title from "Head of PLG and DevRel" to **Head of Developer Experience & Relations** in the four places it appears: homepage hero, blog sidebar, about page (body + meta description), and the site header tagline.

The "hands-on Developer Experience, Developer Relations, Developer Marketing, and PLG leader and advisor" skills sentence is intentionally unchanged.

Build + `npm run verify` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt)_