### PR TITLE
Add expand/collapse mobile navigation menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,26 @@ const guideMenu = [
       </div>
     </div>
     <nav class="site-nav" aria-label="Main">
-      <ul>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav-menu">
+        <svg class="nav-toggle__open" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+          <path
+            d="M3 6h18M3 12h18M3 18h18"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            fill="none"></path>
+        </svg>
+        <svg class="nav-toggle__close" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+          <path
+            d="M5 5l14 14M19 5L5 19"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            fill="none"></path>
+        </svg>
+        Menu
+      </button>
+      <ul id="site-nav-menu">
         <li><a href="/">Home</a></li>
         <li><a href="/blog/">Blog</a></li>
         <li>
@@ -76,3 +95,12 @@ const guideMenu = [
     </nav>
   </div>
 </header>
+
+<script>
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('.site-nav');
+  toggle?.addEventListener('click', () => {
+    const open = nav?.classList.toggle('site-nav--open');
+    toggle.setAttribute('aria-expanded', String(Boolean(open)));
+  });
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,13 @@ const guideMenu = [
       </div>
     </div>
     <nav class="site-nav" aria-label="Main">
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-nav-menu">
+      <button
+        class="nav-toggle"
+        type="button"
+        aria-label="Menu"
+        aria-expanded="false"
+        aria-controls="site-nav-menu"
+      >
         <svg class="nav-toggle__open" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
           <path
             d="M3 6h18M3 12h18M3 18h18"
@@ -65,7 +71,6 @@ const guideMenu = [
             stroke-linecap="round"
             fill="none"></path>
         </svg>
-        Menu
       </button>
       <ul id="site-nav-menu">
         <li><a href="/">Home</a></li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -359,15 +359,12 @@ pre:not(.astro-code) {
 .nav-toggle {
   display: none;
   align-items: center;
-  gap: var(--space-xs);
+  justify-content: center;
   background: rgb(255 255 255 / 0.1);
   color: #fff;
   border: 1px solid rgb(255 255 255 / 0.25);
   border-radius: 6px;
-  padding: var(--space-xs) var(--space-m);
-  font: inherit;
-  font-size: var(--step--1);
-  font-weight: 600;
+  padding: var(--space-xs);
   cursor: pointer;
   margin-bottom: var(--space-s);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -355,7 +355,52 @@ pre:not(.astro-code) {
   color: var(--color-accent);
 }
 
+/* Mobile: hamburger-toggled menu */
+.nav-toggle {
+  display: none;
+  align-items: center;
+  gap: var(--space-xs);
+  background: rgb(255 255 255 / 0.1);
+  color: #fff;
+  border: 1px solid rgb(255 255 255 / 0.25);
+  border-radius: 6px;
+  padding: var(--space-xs) var(--space-m);
+  font: inherit;
+  font-size: var(--step--1);
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: var(--space-s);
+}
+
+.nav-toggle svg {
+  display: none;
+}
+
+.site-nav:not(.site-nav--open) .nav-toggle__open,
+.site-nav--open .nav-toggle__close {
+  display: block;
+}
+
 @media (max-width: 640px) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav > ul {
+    display: none;
+    flex-direction: column;
+    gap: 0;
+    padding-bottom: var(--space-s);
+  }
+
+  .site-nav--open > ul {
+    display: flex;
+  }
+
+  .site-nav a {
+    border-radius: 6px;
+  }
+
   .site-nav ul ul {
     position: static;
     display: block;


### PR DESCRIPTION
At widths ≤640px the nav now collapses behind a **Menu** button:

- Hamburger icon when closed, ✕ when open, with `aria-expanded`/`aria-controls` wired up
- Small vanilla-JS click toggle (no dependencies); menu items stack vertically, guide submenu renders inline
- Desktop/wide layout unchanged

Verified with Playwright at 390px: toggle opens/closes, aria state flips correctly, both visual states screenshot-checked. Build + `npm run verify` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt)_