### PR TITLE
Add Dependabot config: consolidated monthly update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # One consolidated monthly PR bumping all npm dependencies together.
+  # Cloudflare builds it (preview URL + npm run verify) before merge.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  # Track the realtime-web-technologies-guide submodule so content updates
+  # to the guide surface as a PR here too.
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` so dependency updates arrive the way you want them:

- **npm**: all package bumps grouped into **one monthly PR** (previously Dependabot opened one PR per package — 25 of those over the Jekyll years). Each grouped PR gets a Cloudflare preview build + `npm run verify` before merge.
- **gitsubmodule**: the realtime-web-technologies-guide submodule is tracked monthly too, so guide content updates surface as a PR here instead of silently drifting.

Security advisories still trigger prompt PRs, also grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KANsaXhhdPgXbBcod2Ttnt)_